### PR TITLE
correct syntax for fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 1. Clone this repository 
 2. Copy files from `src` to `~/.config/micro/colorschemes` (create folder if it doesn't exist):
-3. Add `export MICRO_TRUECOLOR=1` to your shell RC file (bashrc, zshrc, config.fish ...).
+3. Add `export "MICRO_TRUECOLOR=1"` to your shell RC file (bashrc, zshrc, config.fish ...).
 4. Open Micro, press Ctrl+e, type `set colorscheme catppuccin-mocha` and press Enter.
 5. For other Catppuccin flavours just use it's name (`catppuccin-latte`, `catppuccin-frappe` or `catppuccin-macchiato`) 
 


### PR DESCRIPTION
fish needs "" around its export parameters. bash and the others work with as well, so I suggest using this commit