### PR TITLE
Add transparent variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 2. Copy files from `src` to `~/.config/micro/colorschemes` (create folder if it doesn't exist)
 3. Add `export "MICRO_TRUECOLOR=1"` to your shell RC file (bashrc, zshrc, config.fish ...)
 4. Open Micro, press Ctrl+e, type `set colorscheme catppuccin-mocha` and press Enter
-5. For other Catppuccin flavours just use it's name (`catppuccin-latte`, `catppuccin-frappe` or `catppuccin-macchiato`) 
+5. For other Catppuccin flavours just use it's name (`catppuccin-latte`, `catppuccin-frappe` or `catppuccin-macchiato`). The "transparent" variants are for transparent terminals.
 
 ## 💝 Thanks to
 

--- a/src/catppuccin-frappe-transparent.micro
+++ b/src/catppuccin-frappe-transparent.micro
@@ -1,0 +1,42 @@
+color-link default "#C6D0F5,#00000000"
+color-link comment "#626880"
+
+color-link identifier "#8CAAEE"
+color-link identifier.class "#8CAAEE"
+color-link identifier.var "#8CAAEE"
+
+color-link constant "#EF9F76"
+color-link constant.number "#EF9F76"
+color-link constant.string "#A6D189"
+
+color-link symbol "#F4B8E4"
+color-link symbol.brackets "#EEBEBE"
+color-link symbol.tag "#8CAAEE"
+
+color-link type "#8CAAEE"
+color-link type.keyword "#E5C890"
+
+color-link special "#F4B8E4"
+color-link statement "#CA9EE6"
+color-link preproc "#F4B8E4"
+
+color-link underlined "#99D1DB"
+color-link error "bold #E78284"
+color-link todo "bold #E5C890"
+
+color-link diff-added "#A6D189"
+color-link diff-modified "#E5C890"
+color-link diff-deleted "#E78284"
+
+color-link gutter-error "#E78284"
+color-link gutter-warning "#E5C890"
+
+color-link statusline "#C6D0F5,#292C3C"
+color-link tabbar "#C6D0F5,#292C3C"
+color-link indent-char "#51576D"
+color-link line-number "#51576D"
+color-link current-line-number "#BABBF1"
+
+color-link cursor-line "#414559,#C6D0F5"
+color-link color-column "#414559"
+color-link type.extended "default"

--- a/src/catppuccin-latte-transparent.micro
+++ b/src/catppuccin-latte-transparent.micro
@@ -1,0 +1,42 @@
+color-link default "#4C4F69,#00000000"
+color-link comment "#ACB0BE"
+
+color-link identifier "#1E66F5"
+color-link identifier.class "#1E66F5"
+color-link identifier.var "#1E66F5"
+
+color-link constant "#FE640B"
+color-link constant.number "#FE640B"
+color-link constant.string "#40A02B"
+
+color-link symbol "#EA76CB"
+color-link symbol.brackets "#DD7878"
+color-link symbol.tag "#1E66F5"
+
+color-link type "#1E66F5"
+color-link type.keyword "#DF8E1D"
+
+color-link special "#EA76CB"
+color-link statement "#8839EF"
+color-link preproc "#EA76CB"
+
+color-link underlined "#04A5E5"
+color-link error "bold #D20F39"
+color-link todo "bold #DF8E1D"
+
+color-link diff-added "#40A02B"
+color-link diff-modified "#DF8E1D"
+color-link diff-deleted "#D20F39"
+
+color-link gutter-error "#D20F39"
+color-link gutter-warning "#DF8E1D"
+
+color-link statusline "#4C4F69,#DCE0E8"
+color-link tabbar "#4C4F69,#DCE0E8"
+color-link indent-char "#BCC0CC"
+color-link line-number "#BCC0CC"
+color-link current-line-number "#7287FD"
+
+color-link cursor-line "#CCD0DA,#4C4F69"
+color-link color-column "#CCD0DA"
+color-link type.extended "default"

--- a/src/catppuccin-mocha-transparent.micro
+++ b/src/catppuccin-mocha-transparent.micro
@@ -1,0 +1,42 @@
+color-link default "#C6D0F5,#00000000"
+color-link comment "#585B70"
+
+color-link identifier "#89B4FA"
+color-link identifier.class "#89B4FA"
+color-link identifier.var "#89B4FA"
+
+color-link constant "#FAB387"
+color-link constant.number "#FAB387"
+color-link constant.string "#A6E3A1"
+
+color-link symbol "#F5C2E7"
+color-link symbol.brackets "#F2CDCD"
+color-link symbol.tag "#89B4FA"
+
+color-link type "#89B4FA"
+color-link type.keyword "#F9E2AF"
+
+color-link special "#F5C2E7"
+color-link statement "#CBA6F7"
+color-link preproc "#F5C2E7"
+
+color-link underlined "#89DCEB"
+color-link error "bold #F38BA8"
+color-link todo "bold #F9E2AF"
+
+color-link diff-added "#A6E3A1"
+color-link diff-modified "#F9E2AF"
+color-link diff-deleted "#F38BA8"
+
+color-link gutter-error "#F38BA8"
+color-link gutter-warning "#F9E2AF"
+
+color-link statusline "#CDD6F4,#181825"
+color-link tabbar "#CDD6F4,#181825"
+color-link indent-char "#45475A"
+color-link line-number "#45475A"
+color-link current-line-number "#B4BEFE"
+
+color-link cursor-line "#313244,#C6D0F5"
+color-link color-column "#313244"
+color-link type.extended "default"


### PR DESCRIPTION
Add variants that work well with transparent terminals. Tested with WezTerm.

The implementation is taken straight from here:

https://github.com/zyedidia/micro/issues/1339#issuecomment-1943357353